### PR TITLE
Fix the link to the pipeline for edge detection

### DIFF
--- a/notebooks/pachyderm-opencv.ipynb
+++ b/notebooks/pachyderm-opencv.ipynb
@@ -149,7 +149,7 @@
    "outputs": [],
    "source": [
     "# Create a pipeline\n",
-    "!pachctl create pipeline -f https://raw.githubusercontent.com/pachyderm/pachyderm/master/examples/opencv/edges.json\n",
+    "!pachctl create pipeline -f https://raw.githubusercontent.com/pachyderm/pachyderm/master/examples/opencv/edges.pipeline.json\n",
     "\n",
     "# Check pipeline created jobs\n",
     "!pachctl list job"


### PR DESCRIPTION
After the recent change in the pachyderm examples repository [1], the file we refer to in our Jupyter Notebook script has been renamed. This fix updates the name in our script to make it work just fine.

[1] https://github.com/pachyderm/pachyderm/commit/a9a76f77815cc7402972c72554d95c04e946a334